### PR TITLE
Fix filefield styling

### DIFF
--- a/locations/forms.py
+++ b/locations/forms.py
@@ -1,7 +1,8 @@
-from django.forms import ModelForm, FloatField, inlineformset_factory
+from django.forms import FloatField, ModelForm, inlineformset_factory
 from markdownx.fields import MarkdownxFormField
 
 from locations.models import Location, RaceDistribution
+from utils.widgets.fancybulmafileinput import FancyBulmaFileInput
 
 
 class LocationForm(ModelForm):
@@ -11,6 +12,8 @@ class LocationForm(ModelForm):
     class Meta:
         model = Location
         fields = ("name", "description", "type", "ruler", "history", "map")
+
+        widgets = {'map': FancyBulmaFileInput()}
 
 
 class RaceDistributionForm(ModelForm):

--- a/templates/fancybulmafileinput/file_input.html
+++ b/templates/fancybulmafileinput/file_input.html
@@ -1,0 +1,34 @@
+{% if widget.is_initial or widget.required %}
+    <div class="field">
+        <div class="buttons has-addons">
+            {% if widget.is_initial %}
+                <button class="button is-static">{{ widget.initial_text }}:</button>
+                <button class="button">
+                    <a href="{{ widget.value.url }}">{{ widget.uploaded_file_name }}</a>
+                </button>
+            {% endif %}
+            {% if not widget.required %}
+                <label class="button">
+                    <input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
+                    &nbsp;{{ widget.clear_checkbox_label }}
+                </label>
+            {% endif %}
+        </div>
+    </div>
+{% endif %}
+<div class="file has-name is-fullwidth">
+    <label class="file-label">
+        <input type="{{ widget.type }}" class="file-input"
+               name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}
+               onchange="$(this).siblings('.file-name').text($(this)[0].files[0].name);">
+        <span class="file-cta">
+            <span class="file-icon">
+                <i class="fas fa-upload"></i>
+            </span>
+            <span class="file-label">
+                {{ widget.choose_file_label }}
+            </span>
+        </span>
+        <span class="file-name">{{ widget.uploaded_file_name }}</span>
+    </label>
+</div>

--- a/utils/widgets/fancybulmafileinput.py
+++ b/utils/widgets/fancybulmafileinput.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from django.forms.widgets import CheckboxInput, Input
+from django.utils.translation import gettext_lazy as _
+
+FILE_INPUT_CONTRADICTION = object()
+
+
+class FancyBulmaFileInput(Input):
+    """Custom Bulma File input based on FileInput/ClearableFileInput.
+    A custom class not based on FileInput and ClearableFileInput is necessary
+    to prevent the bulma form filter from modifying this element."""
+    input_type = 'file'
+    needs_multipart_form = True
+    clear_checkbox_label = _('Clear')
+    choose_file_label = _('Choose a file')
+    initial_text = _('Currently')
+    input_text = _('Change')
+    template_name = 'fancybulmafileinput/file_input.html'
+
+    def clear_checkbox_name(self, name):
+        """
+        Given the name of the file input, return the name of the clear checkbox
+        input.
+        """
+        return name + '-clear'
+
+    def clear_checkbox_id(self, name):
+        """
+        Given the name of the clear checkbox input, return the HTML id for it.
+        """
+        return name + '_id'
+
+    def is_initial(self, value):
+        """
+        Return whether value is considered to be initial value.
+        """
+        return bool(value and getattr(value, 'url', False))
+
+    def format_value(self, value):
+        """
+        Return the file object if it has a defined url attribute.
+        """
+        if self.is_initial(value):
+            return value
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        checkbox_name = self.clear_checkbox_name(name)
+        checkbox_id = self.clear_checkbox_id(checkbox_name)
+        uploaded_file_name = Path(str(value)).name
+        context['widget'].update({
+            'checkbox_name': checkbox_name,
+            'checkbox_id': checkbox_id,
+            'is_initial': self.is_initial(value),
+            'input_text': self.input_text,
+            'initial_text': self.initial_text,
+            'clear_checkbox_label': self.clear_checkbox_label,
+            'choose_file_label': self.choose_file_label,
+            'uploaded_file_name': uploaded_file_name,
+        })
+        return context
+
+    def value_from_datadict(self, data, files, name):
+        upload = files.get(name)
+        if not self.is_required and CheckboxInput().value_from_datadict(
+                data, files, self.clear_checkbox_name(name)):
+
+            if upload:
+                # If the user contradicts themselves (uploads a new file AND
+                # checks the "clear" checkbox), we return a unique marker
+                # object that FileField will turn into a ValidationError.
+                return FILE_INPUT_CONTRADICTION
+            # False signals to clear any existing value,
+            # as opposed to just None
+            return False
+        return upload
+
+    def use_required_attribute(self, initial):
+        return super().use_required_attribute(initial) and not initial
+
+    def value_omitted_from_data(self, data, files, name):
+        return (
+                name not in files and
+                self.clear_checkbox_name(name) not in data
+        )


### PR DESCRIPTION
This PR introduces `FancyBulmaFileInput`, a class designed to act like Djangos' `ClearableFileInput` widget, but rendering as a nice Bulma form:
![image](https://user-images.githubusercontent.com/8565229/67282066-25bd0e80-f4d1-11e9-9318-76d0a6322628.png)

Fixes and closes #59 