### PR TITLE
Enhance locations occupancy formset

### DIFF
--- a/locations/templates/locations/create.html
+++ b/locations/templates/locations/create.html
@@ -7,23 +7,7 @@
             <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ form|bulma }}
-                <p><strong>Race Distribution / Occupancy:</strong></p>
-                <div id="form_set">
-                    {{ occupancies.management_form }}
-                    {% for extra_form in occupancies.forms %}
-                        {{ extra_form.non_field_errors }}
-                        {{ extra_form.errors }}
-                        <div>
-                            {{ extra_form|bulma }}
-                        </div>
-                    {% endfor %}
-                </div>
-                <input type="button" value="Additional Inhabitants" id="add_more" class="button is-info">
-                <div id="empty_form" style="display:none">
-                    <table>
-                        {{ occupancies.empty_form|bulma }}
-                    </table>
-                </div>
+                {% include 'locations/race_form.html' %}
                 <hr/>
                 <button type="submit" class="button is-primary">Create Location</button>
             </form>

--- a/locations/templates/locations/create_inner.html
+++ b/locations/templates/locations/create_inner.html
@@ -5,23 +5,7 @@
             <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ form|bulma }}
-                <p><strong>Race Distribution / Occupancy:</strong></p>
-                <div id="form_set">
-                    {{ occupancies.management_form }}
-                    {% for extra_form in occupancies.forms %}
-                        {{ extra_form.non_field_errors }}
-                        {{ extra_form.errors }}
-                        <div>
-                            {{ extra_form|bulma }}
-                        </div>
-                    {% endfor %}
-                </div>
-                <input type="button" value="Additional Inhabitants" id="add_more" class="button is-info">
-                <div id="empty_form" style="display:none">
-                    <table>
-                        {{ occupancies.empty_form|bulma }}
-                    </table>
-                </div>
+                {% include 'locations/race_form.html' %}
                 <hr/>
                 <button type="submit" class="button is-primary">Create Location</button>
             </form>

--- a/locations/templates/locations/edit.html
+++ b/locations/templates/locations/edit.html
@@ -7,23 +7,7 @@
             <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ form|bulma }}
-                <p><strong>Race Distribution / Occupancy:</strong></p>
-                <div id="form_set">
-                    {{ occupancies.management_form }}
-                    {% for extra_form in occupancies.forms %}
-                        {{ extra_form.non_field_errors }}
-                        {{ extra_form.errors }}
-                        <div>
-                            {{ extra_form|bulma }}
-                        </div>
-                    {% endfor %}
-                </div>
-                <input type="button" value="Additional Inhabitants" id="add_more" class="button is-info">
-                <div id="empty_form" style="display:none">
-                    <table>
-                        {{ occupancies.empty_form|bulma }}
-                    </table>
-                </div>
+                {% include 'locations/race_form.html' %}
                 <hr/>
                 <button type="submit" class="button is-primary">Update Location</button>
             </form>

--- a/locations/templates/locations/race_form.html
+++ b/locations/templates/locations/race_form.html
@@ -1,0 +1,26 @@
+{% load bulma_tags %}
+<div class="field">
+    <label class="label">
+        Race Distribution / Occupancy:
+    </label>
+    <div class="control" id="form_set">
+        {{ occupancies.management_form }}
+        {% for extra_form in occupancies.forms %}
+            {{ extra_form.non_field_errors }}
+            {{ extra_form.errors }}
+            <div class="box">
+                {{ extra_form|bulma }}
+            </div>
+        {% endfor %}
+    </div>
+</div>
+<div class="field">
+    <div class="control">
+        <input type="button" value="Additional Inhabitants" id="add_more" class="button is-info">
+    </div>
+</div>
+<div id="empty_form" style="display:none">
+    <div class="box">
+        {{ occupancies.empty_form|bulma }}
+    </div>
+</div>


### PR DESCRIPTION
Before, it was hard to distinguish occupancy/race forms as there were no borders.
Also, code duplications of the occupancy/race forms occured.

This PR introduces a single representation of the occupancy/race form and packs single forms into `box`es for an easier separation: 
![image](https://user-images.githubusercontent.com/8565229/67287009-9c123e80-f4da-11e9-9aac-d9f9672c17aa.png)
